### PR TITLE
implement sigwinch-aware resizing

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -49,6 +49,7 @@
 #define DEFAULT_TTY "/dev/tty"
 #define DEFAULT_PROMPT "> "
 #define DEFAULT_NUM_LINES 10
+#define DEFAULT_AUTO_LINES 0
 #define DEFAULT_WORKERS 0
 #define DEFAULT_SHOW_INFO 0
 #define DEFAULT_DELIMITER '\n'

--- a/src/options.c
+++ b/src/options.c
@@ -106,6 +106,7 @@ options_init(options_t *options)
 	options->scrolloff       = DEFAULT_SCROLLOFF;
 	options->tty_filename    = DEFAULT_TTY;
 	options->num_lines       = DEFAULT_NUM_LINES;
+	options->auto_lines      = DEFAULT_AUTO_LINES;
 	options->prompt          = DEFAULT_PROMPT;
 	options->workers         = DEFAULT_WORKERS;
 	options->input_delimiter = DEFAULT_DELIMITER;
@@ -166,6 +167,9 @@ options_parse(options_t *options, int argc, char *argv[])
 			int l;
 			if (!strcmp(optarg, "max")) {
 				l = INT_MAX;
+			} else if (!strcmp(optarg, "auto")) {
+				l = 0;
+				options->auto_lines = 1;
 //			} else if (sscanf(optarg, "%d", &l) != 1 || l < 3) {
 			} else if (sscanf(optarg, "%d", &l) != 1 || l < 2) {
 				fprintf(stderr, "Invalid format for --lines: %s\n", optarg);

--- a/src/options.h
+++ b/src/options.h
@@ -39,6 +39,7 @@ typedef struct {
 	const char *tty_filename;
 	int show_scores;
 	unsigned int num_lines;
+	int auto_lines;
 	unsigned int scrolloff;
 	const char *prompt;
 	unsigned int workers;

--- a/src/tty_interface.c
+++ b/src/tty_interface.c
@@ -806,12 +806,18 @@ tty_interface_run(tty_interface_t *state)
 {
 	if (state->options->no_color == 0)
 		set_colors();
+	if (state->options->auto_lines)
+		state->options->num_lines = tty_getheight(state->tty) - 1;
 	draw(state);
 
 	for (;;) {
 		do {
 			while(!tty_input_ready(state->tty, -1, 1)) {
 				/* We received a signal (probably WINCH) */
+				if (state->options->auto_lines) {
+					tty_getwinsz(state->tty);
+					state->options->num_lines = tty_getheight(state->tty) - 1;
+				}
 				draw(state);
 			}
 


### PR DESCRIPTION
adds a new `auto_lines` option
currently just fills the entire terminal

also not actually sigwinch aware, that'll need either a global flag or global ref to `tty`