### PR TITLE
Show packaging status from Repology

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Rather than clearing the screen, fzy displays its interface directly below the c
 
 ## Installation
 
-If running on Archlinux, **FNF** can be installed from the [AUR](https://aur.archlinux.org/packages/fnf). Else, perform a manual installation as follows:
+[![Packaging status](https://repology.org/badge/vertical-allrepos/fnf.svg)](https://repology.org/project/fnf/versions)
+**FNF** is availible in multiple package repositories, if there is not a package for your system, perform a manual installation as follows:
 
 ```sh
 mkdir build && cd build


### PR DESCRIPTION
I'm the package maintainer for FNF on Chimera Linux, I think showing the Repology badge would make it easier to know what repositories FNF has been packaged in.